### PR TITLE
Fix CORS preflight for appointments

### DIFF
--- a/demo-spring-petclinic-java/src/main/java/org/springframework/samples/petclinic/config/WebConfig.java
+++ b/demo-spring-petclinic-java/src/main/java/org/springframework/samples/petclinic/config/WebConfig.java
@@ -1,0 +1,16 @@
+package org.springframework.samples.petclinic.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins("http://localhost:8080")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*");
+    }
+}

--- a/demo-spring-petclinic-java/src/main/java/org/springframework/samples/petclinic/security/BasicAuthenticationConfig.java
+++ b/demo-spring-petclinic-java/src/main/java/org/springframework/samples/petclinic/security/BasicAuthenticationConfig.java
@@ -9,6 +9,7 @@ import org.springframework.security.config.annotation.authentication.builders.Au
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.crypto.password.DelegatingPasswordEncoder;
 import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -39,6 +40,7 @@ public class BasicAuthenticationConfig {
         http
             .csrf(AbstractHttpConfigurer::disable)
             .authorizeHttpRequests((authz) -> authz
+                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 .anyRequest().authenticated())
                 .httpBasic(Customizer.withDefaults());
         // @formatter:on


### PR DESCRIPTION
## Summary
- allow OPTIONS requests in security filter chain
- register CORS mappings for API routes

## Testing
- `./mvnw -q -DskipTests=false test` *(fails: maven wrapper missing)*